### PR TITLE
Simplify and shorten code

### DIFF
--- a/R/RCA.r
+++ b/R/RCA.r
@@ -13,27 +13,25 @@
 #' colnames(mat) <- c ("I1", "I2", "I3", "I4")
 #'
 #' ## run the function
-#' RCA (mat)
-#' RCA (mat, binary = TRUE)
+#' RCA(mat)
+#' RCA(mat, binary = TRUE)
 #' @author Pierre-Alexandre Balland \email{p.balland@uu.nl}
 #' @seealso \code{\link{location.quotient}}
 #' @references Balassa, B. (1965) Trade Liberalization and Revealed Comparative Advantage, \emph{The Manchester School} \strong{33}: 99-123.
 
-RCA <- function(mat, binary = FALSE) {
-  mat = as.matrix (mat)
-  share_tech_city <- mat / rowSums (mat)
-  share_tech_total <- colSums (mat) / sum (mat)
+RCA <- function (mat, binary = FALSE) {
+  mat <- as.matrix(mat)
+  share_tech_city  <- mat/rowSums(mat)
+  share_tech_total <- colSums(mat)/sum(mat)
+  
+  LQ <- t(t(share_tech_city)/share_tech_total)
+  LQ[is.na(LQ)] <- 0
+  
   if (binary) {
-    LQ <- t(t(share_tech_city)/ share_tech_total)
-    LQ[is.na(LQ)] <- 0
     LQ[LQ < 1] <- 0
     LQ[LQ > 1] <- 1
-  } else {
-  LQ <- t(t(share_tech_city)/ share_tech_total)
-  LQ[is.na(LQ)] <- 0
-  }
-  return (LQ)
-
+  } 
+  return(LQ)
 }
 
 


### PR DESCRIPTION
Lines 31-32 can also be entirely replaced by 
return((LQ > 1) + 0)
which may be faster and shorter. However, speed is not really a concern here, and this version is a bit more legible. 

> identical(RCA(mat), RCA2(mat))
[1] TRUE
> identical(RCA(mat, TRUE), RCA2(mat, TRUE))
[1] TRUE